### PR TITLE
Improve iOS perfs and podspec

### DIFF
--- a/ios/stockfish.podspec
+++ b/ios/stockfish.podspec
@@ -12,13 +12,15 @@ Pod::Spec.new do |s|
   s.version          = pubspec['version']
   s.summary          = pubspec['description']
   s.homepage         = pubspec['homepage']
-  s.license          = { :file => '../LICENSE' }
+  s.license          = { :file => '../LICENSE', :type => 'MIT' }
   s.author           = 'Arjan Aswal'
-  s.source           = { :path => '.' }
+  s.source = { :git => pubspec['repository'], :tag => s.version.to_s }
   s.source_files = 'Classes/**/*', 'FlutterStockfish/*', 'Stockfish/src/**/*'
   s.public_header_files = 'Classes/**/*.h'
+  s.exclude_files = 'Stockfish/src/incbin/UNLICENCE'
   s.dependency 'Flutter'
   s.platform = :ios, '11.0'
+  s.ios.deployment_target  = '11.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/stockfish.podspec
+++ b/ios/stockfish.podspec
@@ -2,16 +2,18 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint stockfish.podspec' to validate before publishing.
 #
+#
+require 'yaml'
+
+pubspec = YAML.load(File.read(File.join(__dir__, '../pubspec.yaml')))
+
 Pod::Spec.new do |s|
-  s.name             = 'stockfish'
-  s.version          = '0.0.1'
-  s.summary          = 'The Stockfish Chess Engine for Flutter.'
-  s.description      = <<-DESC
-The Stockfish Chess Engine for Flutter.
-                       DESC
-  s.homepage         = 'http://example.com'
+  s.name             = pubspec['name']
+  s.version          = pubspec['version']
+  s.summary          = pubspec['description']
+  s.homepage         = pubspec['homepage']
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = 'Arjan Aswal'
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*', 'FlutterStockfish/*', 'Stockfish/src/**/*'
   s.public_header_files = 'Classes/**/*.h'
@@ -31,6 +33,7 @@ The Stockfish Chess Engine for Flutter.
   s.xcconfig = {
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
     'CLANG_CXX_LIBRARY' => 'libc++',
-    'OTHER_CPLUSPLUSFLAGS' => '$(inherited) -w'
+    'OTHER_CPLUSPLUSFLAGS' => '$(inherited) -fno-exceptions -std=c++17 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -flto=thin',
+    'OTHER_LDFLAGS' => '$(inherited) -fno-exceptions -std=c++17 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -flto=thin'
   }
 end


### PR DESCRIPTION
- podspec basic infos are now synced with `pubspec.yaml`
- added cpp compiler flags (same as I used in https://github.com/veloce/capacitor-stockfish), the engine now runs 10x faster on iOS
- fixed a couple of podspec lint warnings