### PR TITLE
Improve android performance

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -7,5 +7,6 @@ add_library(
   ../ios/FlutterStockfish/ffi.cpp
   ${cppPaths}
 )
+target_compile_options(stockfish PRIVATE -std=c++17 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -DUSE_POPCNT -DUSE_NEON)
 
 file(DOWNLOAD https://tests.stockfishchess.org/api/nn/nn-6877cd24400e.nnue ${CMAKE_BINARY_DIR}/nn-6877cd24400e.nnue)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,10 +25,11 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         externalNativeBuild {
             cmake {
-                cppFlags "-std=c++17"
+                arguments '-DANDROID_ARM_NEON=TRUE'
+                abiFilters 'arm64-v8a'
             }
         }
     }
@@ -37,7 +38,7 @@ android {
     }
     externalNativeBuild {
         cmake {
-            path "CMakeLists.txt"
+            path 'CMakeLists.txt'
         }
     }
 }


### PR DESCRIPTION
Since NEON is not supported in armv7 devices I used an abi filter to keep only armv8.

So it's up to you if you want to merge this. Note that afaik performance of NNUE evaluation is really degraded without NEON support, so older devices should use classical evaluation instead.

To solve this problem in current lichess application, I use 2 engines: one compiled with NNUE and NEON for armv8 and one compiled without for armv7.

The best solution, perhaps, would be to compile it for both architectures using different flags for each one, but I don't know how to do that.