### PR TITLE
Exclude x86 since flutter doesn't support it

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,9 @@ android {
 
     defaultConfig {
         minSdkVersion 16
+        ndk {
+            abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86_64'
+        }
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++17"


### PR DESCRIPTION
I received a pre-launch report from google play that shows a crash:

```
Device(s) with issues
Google Pixel 2 (Pixel2Emulator) - Android 9

Exceptions
java.lang.RuntimeException: Unable to start activity ComponentInfo{org.lichess.mobileV2/org.lichess.mobileV2.MainActivity}: java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.UnsatisfiedLinkError: dalvik.system.PathClassLoader[DexPathList[[zip file "/system/framework/android.test.runner.jar", zip file "/system/framework/org.apache.http.legacy.boot.jar", zip file "/system/framework/android.test.mock.jar", zip file "/data/app/androidx.test.tools.crawler-CJEf05fYCO4HIf-z7lg_Xw==/base.apk", zip file "/data/app/org.lichess.mobileV2-GCEPVCmlAyvqSf6kCUzqDg==/base.apk", zip file "/data/app/org.lichess.mobileV2-GCEPVCmlAyvqSf6kCUzqDg==/split_config.en.apk", zip file "/data/app/org.lichess.mobileV2-GCEPVCmlAyvqSf6kCUzqDg==/split_config.x86.apk", zip file "/data/app/org.lichess.mobileV2-GCEPVCmlAyvqSf6kCUzqDg==/split_config.xxhdpi.apk"],nativeLibraryDirectories=[/data/app/androidx.test.tools.crawler-CJEf05fYCO4HIf-z7lg_Xw==/lib/x86, /data/app/org.lichess.mobileV2-GCEPVCmlAyvqSf6kCUzqDg==/lib/x86, /data/app/androidx.test.tools.crawler-CJEf05fYCO4HIf-z7lg_Xw==/base.apk!/lib/x86, /data/app/org.lichess.mobileV2-GCEPVCmlAyvqSf6kCUzqDg==/base.apk!/lib/x86, /data/app/org.lichess.mobileV2-GCEPVCmlAyvqSf6kCUzqDg==/split_config.en.apk!/lib/x86, /data/app/org.lichess.mobileV2-GCEPVCmlAyvqSf6kCUzqDg==/split_config.x86.apk!/lib/x86, /data/app/org.lichess.mobileV2-GCEPVCmlAyvqSf6kCUzqDg==/split_config.xxhdpi.apk!/lib/x86, /system/lib]]] couldn't find "libflutter.so"
```

And I believe the stockfish plugin is the cause because this is the first time I received such a report, since I introduced the plugin. 
I pushed a new app and I haven't received a report so far.

