### PR TITLE
Replace debug print statements with a logger

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  logging:
+    dependency: "direct main"
+    description:
+      name: logging
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   ffi: ^2.0.0
   flutter:
     sdk: flutter
+  logging: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Using dart official `logging` package.

This has the benefit of giving more control to the user of what to display with log levels. (Even though I just used `fine` and `severe` for now because it seemed the most appropriate).

Also it shows the log directly under `Stockfish` name and not `flutter:`.