### PR TITLE
Add Android 16KB page size support for Google Play compliance

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4.1)
 
-# Enable 16KB page size support for Android (required for Google Play as of May 2026)
+# Enable 16KB page size support for Android (required for Google Play)
 add_link_options(-Wl,-z,max-page-size=16384)
 add_link_options(-Wl,-z,common-page-size=16384)
 

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.4.1)
 
+# Enable 16KB page size support for Android (required for Google Play as of May 2026)
+add_link_options(-Wl,-z,max-page-size=16384)
+add_link_options(-Wl,-z,common-page-size=16384)
+
 file(GLOB_RECURSE cppPaths "../ios/Stockfish/src/*.cpp")
 add_library(
   stockfish


### PR DESCRIPTION
# Problem
Google Play now requires apps targeting Android 15+ to support 16KB memory page sizes. Currently, `libstockfish.so` is compiled with 4KB alignment, which will cause app rejections starting November 2025.

# Solution
Added linker flags to android/CMakeLists.txt to enforce 16KB alignment:
```
add_link_options(-Wl,-z,max-page-size=16384)
add_link_options(-Wl,-z,common-page-size=16384)
```

# Testing
- Verified using `bundletool` and `llvm-readelf` to check native library alignment. I didn't actually upload to google play yet so I'm 99% sure it works.
     - Before fix: libstockfish.so   4KB aligned (0x1000)
     - After fix: libstockfish.so   16KB aligned (0x4000)
- Checked that stockfish engine is still working in my app.

